### PR TITLE
Fix API key header parsing

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -1,6 +1,6 @@
 import secrets
 import hashlib
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, Header, HTTPException, status
 from sqlalchemy.orm import Session
 from .database import SessionLocal
 from .models import APIKey
@@ -34,7 +34,7 @@ def verify_api_key(key: str, db: Session) -> APIKey:
     return api_key
 
 
-def get_current_key(authorization: str = Depends(lambda: None), db: Session = Depends(get_db)) -> APIKey:
+def get_current_key(authorization: str = Header(None), db: Session = Depends(get_db)) -> APIKey:
     if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
     token = authorization.split(" ", 1)[1]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,62 @@
+import os
+import sys
+import pytest
+from fastapi import FastAPI, Depends
+from fastapi.testclient import TestClient
+
+# Ensure project root is on sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Ensure database URL is set before importing app modules
+TEST_DB = '/tmp/test.db'
+if os.path.exists(TEST_DB):
+    os.remove(TEST_DB)
+os.environ['DATABASE_URL'] = f'sqlite:///{TEST_DB}'
+
+from app.models import Base
+from app.database import engine, SessionLocal
+from app.auth import create_api_key, get_current_key
+
+# Create tables for test DB
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+
+@app.get("/protected")
+def protected(api_key=Depends(get_current_key)):
+    return {"owner": api_key.owner}
+
+client = TestClient(app)
+
+
+def setup_module(module):
+    # Reset database state
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def test_get_current_key_missing_header():
+    response = client.get("/protected")
+    assert response.status_code == 401
+
+
+def test_get_current_key_valid_header():
+    with SessionLocal() as db:
+        key = create_api_key(db, "tester")
+    headers = {"Authorization": f"Bearer {key}"}
+    response = client.get("/protected", headers=headers)
+    assert response.status_code == 200
+    assert response.json() == {"owner": "tester"}
+
+def test_get_current_key_invalid_token():
+    headers = {"Authorization": "Bearer invalid"}
+    response = client.get("/protected", headers=headers)
+    assert response.status_code == 401
+
+
+def test_get_current_key_invalid_prefix():
+    with SessionLocal() as db:
+        key = create_api_key(db, "tester2")
+    headers = {"Authorization": key}  # missing Bearer prefix
+    response = client.get("/protected", headers=headers)
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary
- parse `Authorization` header via `Header` dependency
- add regression tests for key parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842546b256083329bcdb120b1401a7c