### PR TITLE
Fix admin token check for API key creation

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1,7 +1,19 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 from .config import get_settings
 
 settings = get_settings()
-engine = create_engine(settings.database_url, connect_args={"check_same_thread": False})
+if settings.database_url.startswith("sqlite") and (
+    ":memory:" in settings.database_url or "mode=memory" in settings.database_url
+):
+    engine = create_engine(
+        settings.database_url,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+else:
+    engine = create_engine(
+        settings.database_url, connect_args={"check_same_thread": False}
+    )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/app/routers/apikeys.py
+++ b/app/routers/apikeys.py
@@ -7,7 +7,7 @@ router = APIRouter(prefix="/apikeys", tags=["apikeys"])
 
 
 @router.post("/", status_code=201)
-def generate_key(owner: str, admin_token: str = Depends(lambda: None), db: Session = Depends(get_db)):
+def generate_key(owner: str, admin_token: str, db: Session = Depends(get_db)):
     settings = get_settings()
     if admin_token != settings.admin_token:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid admin token")

--- a/tests/test_apikeys.py
+++ b/tests/test_apikeys.py
@@ -1,0 +1,36 @@
+import os
+import sys
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+os.environ['ADMIN_TOKEN'] = 'admintest'
+
+from app.models import Base
+from app.database import engine
+from app.routers.apikeys import router
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+app.include_router(router)
+client = TestClient(app)
+
+
+def setup_module(module):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def test_generate_key_success():
+    response = client.post('/apikeys/?owner=alice&admin_token=admintest')
+    assert response.status_code == 201
+    data = response.json()
+    assert 'api_key' in data and data['api_key']
+
+
+def test_generate_key_invalid_admin_token():
+    response = client.post('/apikeys/?owner=bob&admin_token=wrong')
+    assert response.status_code == 401

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -8,10 +8,8 @@ from fastapi.testclient import TestClient
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Ensure database URL is set before importing app modules
-TEST_DB = '/tmp/test.db'
-if os.path.exists(TEST_DB):
-    os.remove(TEST_DB)
-os.environ['DATABASE_URL'] = f'sqlite:///{TEST_DB}'
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+os.environ['ADMIN_TOKEN'] = 'admintest'
 
 from app.models import Base
 from app.database import engine, SessionLocal


### PR DESCRIPTION
## Summary
- fix API key generation endpoint to read `admin_token` from query params
- support in-memory SQLite during tests
- add regression tests for `/apikeys` router

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f3c1a75c8332ba8288ad0aa6a9e6