### PR TITLE
Add subdomains scan endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # WVR API
 
-API hub para ferramentas de OSINT e Cybersecurity utilizando FastAPI. Atualmente
-suporta execuções do Nmap e permite gerenciar chaves de acesso por meio de API
-keys.
+API hub para ferramentas de OSINT e Cybersecurity utilizando FastAPI. Atualmente suporta execuções do Nmap, busca de subdomínios com Sublist3r e permite gerenciar chaves de acesso por meio de API keys.
 
 ## Executando com Docker
 
@@ -93,5 +91,30 @@ Resposta:
   "target": "scanme.nmap.org",
   "options": "-sV",
   "result": "...saída do nmap..."
+}
+```
+
+
+### POST `/api/v1/subdomains/scan`
+
+Executa uma enumeração de subdomínios utilizando o Sublist3r. É necessário enviar a API key no cabeçalho `Authorization: Bearer <API_KEY>`.
+
+Parâmetros (query):
+
+- `domain` (**obrigatório**) &mdash; domínio a ser pesquisado.
+
+Exemplo:
+
+```bash
+curl -X POST "http://localhost:8000/api/v1/subdomains/scan?domain=example.com" \
+  -H "Authorization: Bearer <API_KEY>"
+```
+
+Resposta:
+
+```json
+{
+  "domain": "example.com",
+  "subdomains": ["www.example.com", "blog.example.com"]
 }
 ```

--- a/app/main.py
+++ b/app/main.py
@@ -2,9 +2,9 @@ from fastapi import FastAPI
 from .config import get_settings
 from .database import engine
 from .models import Base
-from .routers import nmap, apikeys
-
+from .routers import nmap, apikeys, subdomains
 settings = get_settings()
+
 
 Base.metadata.create_all(bind=engine)
 
@@ -12,3 +12,4 @@ app = FastAPI(title="WVR API")
 
 app.include_router(apikeys.router, prefix=settings.api_v1_prefix)
 app.include_router(nmap.router, prefix=settings.api_v1_prefix)
+app.include_router(subdomains.router, prefix=settings.api_v1_prefix)

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,3 +1,3 @@
-from . import nmap, apikeys
+from . import nmap, apikeys, subdomains
 
-__all__ = ["nmap", "apikeys"]
+__all__ = ["nmap", "apikeys", "subdomains"]

--- a/app/routers/subdomains.py
+++ b/app/routers/subdomains.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter, Depends, HTTPException
+from ..auth import get_current_key
+from ..utils.sublist3r_runner import run_sublist3r
+
+router = APIRouter(prefix="/subdomains", tags=["subdomains"])
+
+@router.post("/scan")
+def enumerate_subdomains(domain: str, api_key=Depends(get_current_key)):
+    try:
+        subdomains = run_sublist3r(domain)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"domain": domain, "subdomains": subdomains}

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,1 +1,2 @@
-
+from .nmap_runner import run_nmap
+from .sublist3r_runner import run_sublist3r

--- a/app/utils/sublist3r_runner.py
+++ b/app/utils/sublist3r_runner.py
@@ -1,0 +1,6 @@
+from sublist3r import main as sublist3r_main
+
+
+def run_sublist3r(domain: str) -> list[str]:
+    """Run Sublist3r and return the list of discovered subdomains."""
+    return sublist3r_main(domain, 40, None, None, True, False, False, None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 fastapi
 uvicorn
 sqlalchemy
+sublist3r
+httpx

--- a/tests/test_subdomains.py
+++ b/tests/test_subdomains.py
@@ -1,0 +1,42 @@
+import os
+import sys
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Add project root to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+os.environ['ADMIN_TOKEN'] = 'admintest'
+
+from app.models import Base
+from app.database import engine, SessionLocal
+from app.auth import create_api_key
+from app.routers.subdomains import router
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+app.include_router(router)
+client = TestClient(app)
+
+
+def setup_module(module):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def test_subdomains_scan(monkeypatch):
+    def fake_run(domain: str):
+        return ["a." + domain, "b." + domain]
+
+    monkeypatch.setattr("app.routers.subdomains.run_sublist3r", fake_run)
+    with SessionLocal() as db:
+        key = create_api_key(db, "tester")
+    headers = {"Authorization": f"Bearer {key}"}
+    response = client.post("/subdomains/scan?domain=example.com", headers=headers)
+    assert response.status_code == 200
+    assert response.json() == {
+        "domain": "example.com",
+        "subdomains": ["a.example.com", "b.example.com"],
+    }


### PR DESCRIPTION
## Summary
- add new `/subdomains/scan` route using Sublist3r
- expose new utility for running Sublist3r
- update FastAPI router registration
- document new endpoint in README
- add tests for subdomains route
- update dependencies

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843184d88448332a64e6f285aa6706d